### PR TITLE
Just a minor fixup (fixing the io_signature template)

### DIFF
--- a/src/modtool_add.py
+++ b/src/modtool_add.py
@@ -21,7 +21,7 @@ class ModToolAdd(ModTool):
     def __init__(self):
         ModTool.__init__(self)
         self._info['inputsig'] = "<+MIN_IN+>, <+MAX_IN+>, sizeof (<+float+>)"
-        self._info['outputsig'] = "<+MIN_IN+>, <+MAX_IN+>, sizeof (<+float+>)"
+        self._info['outputsig'] = "<+MIN_OUT+>, <+MAX_OUT+>, sizeof (<+float+>)"
         self._add_cc_qa = False
         self._add_py_qa = False
 


### PR DESCRIPTION
I've always ignored the fact that the output io_signature of a C++ block
has been prefilled with <+MIN_IN+>/OUT+>. 
Now I fixed that.
