### PR TITLE
fix a mismatched #end in SWIG templates

### DIFF
--- a/gr_modtool.py
+++ b/gr_modtool.py
@@ -630,7 +630,7 @@ GR_SWIG_BLOCK_MAGIC($modname, $blockname);
 #else
 %include "${modname}/${blockname}.h"
 GR_SWIG_BLOCK_MAGIC2($modname, $blockname);
-#end
+#end if
 """
 
 ## Old stuff

--- a/src/templates.py
+++ b/src/templates.py
@@ -501,7 +501,7 @@ GR_SWIG_BLOCK_MAGIC($modname, $blockname);
 #else
 %include "${modname}/${blockname}.h"
 GR_SWIG_BLOCK_MAGIC2($modname, $blockname);
-#end
+#end if
 """
 
 ## Old stuff


### PR DESCRIPTION
I know almost nothing about SWIG, but it seems it wants `#end if` not `#end` here.
